### PR TITLE
Improve methods supporting return type of any subgraph env

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,15 @@
 import { RPCProvider, SupportedChainsValues, RPCProviderConfig } from '@businessLogic/chains'
-import { BadgeStatus } from '@subgraph/prod/generated/subgraph'
+import { BadgeStatus as BadgeStatus_DEV } from '@subgraph/dev/generated/subgraph'
+import { BadgeStatus as BadgeStatus_STAGING } from '@subgraph/staging/generated/subgraph'
+import { BadgeStatus as BadgeStatus_PROD } from '@subgraph/prod/generated/subgraph'
 import { Web3Provider } from '@ethersproject/providers'
 import { BadgesService } from './services/badges/badges'
 import { BadgeModelsService } from './services/badgeModels/badgeModels'
 import { UsersService } from './services/users/users'
 import { TheBadgeSDKPermissions } from '@businessLogic/sdk/permissions'
-import { TheBadgeSDKConfig, TheBadgeSDKConfigOptions } from '@businessLogic/sdk/config'
+import { TheBadgeSDKConfig, TheBadgeSDKConfigOptions, TheBadgeSDKEnv } from '@businessLogic/sdk/config'
+
+type BadgeStatus = BadgeStatus_DEV | BadgeStatus_STAGING | BadgeStatus_PROD
 
 class TheBadgeSDK extends TheBadgeSDKConfig {
   public readonly badges: BadgesService
@@ -37,8 +41,10 @@ class TheBadgeSDK extends TheBadgeSDKConfig {
    * - rpcProviderConfig provides the configuration for the read only provider: (name, apiKey)
    *      - name: string (for now only available 'infura' or 'alchemy'),
    *      - apiKey: string
-   * - web3Provider is an optional parameter with the web 3 provider to perform write requests to a contract
-   * - devMode is an optional parameter to use DEV data if the selected chain supports it
+   * - web3Provider is an optional parameter with the web3 provider to perform write requests to a contract
+   * - devMode is an @optional boolean parameter to use DEV data if the selected chain supports it:
+   *      - For testnets: if devMode is true, development env data will be used. If false, staging env data will be used.
+   *      - For mainnets: always production env data is used, no matter what value this flag has.
    */
   constructor(chainId: SupportedChainsValues, config: TheBadgeSDKConfigOptions) {
     super(chainId, config)
@@ -51,6 +57,7 @@ class TheBadgeSDK extends TheBadgeSDKConfig {
 
   /**
    * Get id of the chain used on this instance
+   *
    * @returns number
    */
   public getChainId(): SupportedChainsValues {
@@ -59,6 +66,7 @@ class TheBadgeSDK extends TheBadgeSDKConfig {
 
   /**
    * Get the name of the RPC provider (for now only 'infura' and 'alchemy' supported)
+   *
    * @returns RPCProvider
    */
   public getRPCProviderName(): RPCProvider {
@@ -67,6 +75,7 @@ class TheBadgeSDK extends TheBadgeSDKConfig {
 
   /**
    * Get the given web3Provider
+   *
    * @returns Web3Provider | undefined
    */
   public getWeb3Provider(): Web3Provider | undefined {
@@ -74,7 +83,8 @@ class TheBadgeSDK extends TheBadgeSDKConfig {
   }
 
   /**
-   * Get current permissions, options:
+   * Get current permissions
+   *
    * @returns READ_ONLY if no web3Provider was given
    * @returns READ_AND_WRITE if a web3Provider was given
    */
@@ -83,22 +93,15 @@ class TheBadgeSDK extends TheBadgeSDKConfig {
   }
 
   /**
-   * Checks if devMode is set.
-   * Important: this field only has an effect if the selected chain (from given chainId) is a testnet.
+   * Get current env
    *
-   * For testnets:
-   * If devMode is true, DEV environment data will be used.
-   * If devMode is false, QA environment data will be used.
-   *
-   * For mainnets (prod env): always production data is used, no matter what value this flag has.
-   *
-   * @returns boolean
+   * @returns TheBadgeSDKEnv (DEVELOPMENT, STAGING or PRODUCTION)
    */
-  public isDevMode(): boolean {
-    return this.devMode
+  public getEnv(): TheBadgeSDKEnv {
+    return this.env
   }
 }
 
-export { TheBadgeSDK, RPCProvider, TheBadgeSDKPermissions }
+export { TheBadgeSDK, RPCProvider, TheBadgeSDKPermissions, TheBadgeSDKEnv }
 
 export type { TheBadgeSDKConfigOptions, RPCProviderConfig, SupportedChainsValues, BadgeStatus }

--- a/src/sdk.spec.ts
+++ b/src/sdk.spec.ts
@@ -1,4 +1,4 @@
-import { RPCProvider, RPCProviderConfig, TheBadgeSDK, TheBadgeSDKPermissions } from './index'
+import { RPCProvider, RPCProviderConfig, TheBadgeSDK, TheBadgeSDKEnv, TheBadgeSDKPermissions } from './index'
 import { Web3Provider } from '@ethersproject/providers'
 import { SupportedChains } from '@businessLogic/chains'
 
@@ -23,13 +23,14 @@ describe('TheBadgeSDK', () => {
     const sdk1 = new TheBadgeSDK(5, { rpcProviderConfig: infuraProvider })
     expect(sdk1.getChainId()).toBe(5)
     expect(sdk1.getRPCProviderName()).toBe(RPCProvider.infura)
-    expect(sdk1.isDevMode()).toBeFalsy()
+    expect(sdk1.getEnv()).toBe(TheBadgeSDKEnv.STAGING)
     expect(sdk1.getWeb3Provider()).toBeUndefined()
     expect(sdk1.getPermissions()).toBe(TheBadgeSDKPermissions.READ_ONLY)
+
     const sdk2 = new TheBadgeSDK(11155111, { rpcProviderConfig: alchemyProvider })
     expect(sdk2.getChainId()).toBe(11155111)
     expect(sdk2.getRPCProviderName()).toBe(RPCProvider.alchemy)
-    expect(sdk2.isDevMode()).toBeFalsy()
+    expect(sdk2.getEnv()).toBe(TheBadgeSDKEnv.STAGING)
     expect(sdk2.getWeb3Provider()).toBeUndefined()
     expect(sdk2.getPermissions()).toBe(TheBadgeSDKPermissions.READ_ONLY)
 
@@ -41,9 +42,11 @@ describe('TheBadgeSDK', () => {
     })
     expect(sdk3.getChainId()).toBe(5)
     expect(sdk3.getRPCProviderName()).toBe(RPCProvider.alchemy)
-    expect(sdk3.isDevMode()).toBeTruthy()
+    expect(sdk3.getEnv()).toBe(TheBadgeSDKEnv.DEVELOPMENT)
     expect(sdk3.getWeb3Provider()).not.toBeUndefined()
     expect(sdk3.getPermissions()).toBe(TheBadgeSDKPermissions.READ_AND_WRITE)
+
+    // TODO add test checking init prod sdk when a mainnet chain is available
   })
 
   it('should initialize the needed services correctly', () => {

--- a/src/services/badgeModels/badgeModels.ts
+++ b/src/services/badgeModels/badgeModels.ts
@@ -1,12 +1,32 @@
 import {
-  BadgeModel_Filter,
-  BadgeModelByIdQuery,
-  BadgeModelsQuery,
-  BadgeModelMetadataByIdQuery,
+  BadgeModel_Filter as BadgeModel_Filter_DEV,
+  BadgeModelByIdQuery as BadgeModelByIdQuery_DEV,
+  BadgeModelsQuery as BadgeModelsQuery_DEV,
+  BadgeModelMetadataByIdQuery as BadgeModelMetadataByIdQuery_DEV,
+} from '@subgraph/dev/generated/subgraph'
+import {
+  BadgeModel_Filter as BadgeModel_Filter_STAGING,
+  BadgeModelByIdQuery as BadgeModelByIdQuery_STAGING,
+  BadgeModelsQuery as BadgeModelsQuery_STAGING,
+  BadgeModelMetadataByIdQuery as BadgeModelMetadataByIdQuery_STAGING,
+} from '@subgraph/staging/generated/subgraph'
+import {
+  BadgeModel_Filter as BadgeModel_Filter_PROD,
+  BadgeModelByIdQuery as BadgeModelByIdQuery_PROD,
+  BadgeModelsQuery as BadgeModelsQuery_PROD,
+  BadgeModelMetadataByIdQuery as BadgeModelMetadataByIdQuery_PROD,
 } from '@subgraph/prod/generated/subgraph'
 import { TheBadgeSDKConfig } from '@businessLogic/sdk/config'
-import { getFromIPFS } from '@utils/ipfs'
 import { MetadataColumn } from '@businessLogic/kleros/types'
+import { getFromIPFS } from '@utils/ipfs'
+
+type BadgeModel_Filter = BadgeModel_Filter_DEV | BadgeModel_Filter_STAGING | BadgeModel_Filter_PROD
+type BadgeModelByIdQuery = BadgeModelByIdQuery_DEV | BadgeModelByIdQuery_STAGING | BadgeModelByIdQuery_PROD
+type BadgeModelsQuery = BadgeModelsQuery_DEV | BadgeModelsQuery_STAGING | BadgeModelsQuery_PROD
+type BadgeModelMetadataByIdQuery =
+  | BadgeModelMetadataByIdQuery_DEV
+  | BadgeModelMetadataByIdQuery_STAGING
+  | BadgeModelMetadataByIdQuery_PROD
 
 interface BadgeModelsServiceMethods {
   get(searchParams?: { first: number; skip: number; filter?: BadgeModel_Filter }): Promise<BadgeModelsQuery>

--- a/src/services/badges/badges.ts
+++ b/src/services/badges/badges.ts
@@ -1,33 +1,98 @@
 import {
-  BadgeByBadgeModelIdQuery,
-  BadgeByIdQuery,
-  BadgesByUserQuery,
-  BadgesChallengedQuery,
-  BadgesInReviewOrChallengedQuery,
-  BadgesInReviewQuery,
-  BadgeStatus,
-  BadgesUserCanReviewQuery,
-  BadgesOfUserByStatusesQuery,
-  BadgesNotOfUserByStatusesQuery,
-  Badge_Filter,
-  BadgesQuery,
-  BadgeMetadataByIdQuery,
-  BadgesMetadataUserHasChallengedQuery,
+  BadgeByBadgeModelIdQuery as BadgeByBadgeModelIdQuery_DEV,
+  BadgeByIdQuery as BadgeByIdQuery_DEV,
+  BadgesByUserQuery as BadgesByUserQuery_DEV,
+  BadgesChallengedQuery as BadgesChallengedQuery_DEV,
+  BadgesInReviewOrChallengedQuery as BadgesInReviewOrChallengedQuery_DEV,
+  BadgesInReviewQuery as BadgesInReviewQuery_DEV,
+  BadgeStatus as BadgeStatus_DEV,
+  BadgesUserCanReviewQuery as BadgesUserCanReviewQuery_DEV,
+  BadgesOfUserByStatusesQuery as BadgesOfUserByStatusesQuery_DEV,
+  BadgesNotOfUserByStatusesQuery as BadgesNotOfUserByStatusesQuery_DEV,
+  Badge_Filter as Badge_Filter_DEV,
+  BadgesQuery as BadgesQuery_DEV,
+  BadgeMetadataByIdQuery as BadgeMetadataByIdQuery_DEV,
+  BadgesMetadataUserHasChallengedQuery as BadgesMetadataUserHasChallengedQuery_DEV,
+} from '@subgraph/dev/generated/subgraph'
+import {
+  BadgeByBadgeModelIdQuery as BadgeByBadgeModelIdQuery_STAGING,
+  BadgeByIdQuery as BadgeByIdQuery_STAGING,
+  BadgesByUserQuery as BadgesByUserQuery_STAGING,
+  BadgesChallengedQuery as BadgesChallengedQuery_STAGING,
+  BadgesInReviewOrChallengedQuery as BadgesInReviewOrChallengedQuery_STAGING,
+  BadgesInReviewQuery as BadgesInReviewQuery_STAGING,
+  BadgeStatus as BadgeStatus_STAGING,
+  BadgesUserCanReviewQuery as BadgesUserCanReviewQuery_STAGING,
+  BadgesOfUserByStatusesQuery as BadgesOfUserByStatusesQuery_STAGING,
+  BadgesNotOfUserByStatusesQuery as BadgesNotOfUserByStatusesQuery_STAGING,
+  Badge_Filter as Badge_Filter_STAGING,
+  BadgesQuery as BadgesQuery_STAGING,
+  BadgeMetadataByIdQuery as BadgeMetadataByIdQuery_STAGING,
+  BadgesMetadataUserHasChallengedQuery as BadgesMetadataUserHasChallengedQuery_STAGING,
+} from '@subgraph/staging/generated/subgraph'
+import {
+  BadgeByBadgeModelIdQuery as BadgeByBadgeModelIdQuery_PROD,
+  BadgeByIdQuery as BadgeByIdQuery_PROD,
+  BadgesByUserQuery as BadgesByUserQuery_PROD,
+  BadgesChallengedQuery as BadgesChallengedQuery_PROD,
+  BadgesInReviewOrChallengedQuery as BadgesInReviewOrChallengedQuery_PROD,
+  BadgesInReviewQuery as BadgesInReviewQuery_PROD,
+  BadgeStatus as BadgeStatus_PROD,
+  BadgesUserCanReviewQuery as BadgesUserCanReviewQuery_PROD,
+  BadgesOfUserByStatusesQuery as BadgesOfUserByStatusesQuery_PROD,
+  BadgesNotOfUserByStatusesQuery as BadgesNotOfUserByStatusesQuery_PROD,
+  Badge_Filter as Badge_Filter_PROD,
+  BadgesQuery as BadgesQuery_PROD,
+  BadgeMetadataByIdQuery as BadgeMetadataByIdQuery_PROD,
+  BadgesMetadataUserHasChallengedQuery as BadgesMetadataUserHasChallengedQuery_PROD,
 } from '@subgraph/prod/generated/subgraph'
+import { ContractTransaction } from 'ethers'
 import { TheBadgeSDKConfig } from '@businessLogic/sdk/config'
-import { getFromIPFS } from '@utils/ipfs'
 import { MetadataColumn } from '@businessLogic/kleros/types'
+import { BadgeModelMetadata } from '@businessLogic/theBadge/BadgeMetadata'
+import { BackendFileResponse } from '@businessLogic/types'
+import { getFromIPFS } from '@utils/ipfs'
 import {
   createAndUploadBadgeEvidence,
   createAndUploadBadgeMetadata,
   createEvidencesValuesObject,
   encodeIpfsEvidence,
 } from '@utils/badges/mintHelpers'
-import { BadgeModelMetadata } from '@businessLogic/theBadge/BadgeMetadata'
 import { KlerosListStructure } from '@utils/kleros/generateKlerosListMetaEvidence'
-import { BackendFileResponse } from '@businessLogic/types'
-import { ContractTransaction } from 'ethers'
 import { schemaFactory } from '@utils/zod/validators'
+
+type BadgeByBadgeModelIdQuery =
+  | BadgeByBadgeModelIdQuery_DEV
+  | BadgeByBadgeModelIdQuery_STAGING
+  | BadgeByBadgeModelIdQuery_PROD
+type BadgeByIdQuery = BadgeByIdQuery_DEV | BadgeByIdQuery_STAGING | BadgeByIdQuery_PROD
+type BadgesByUserQuery = BadgesByUserQuery_DEV | BadgesByUserQuery_STAGING | BadgesByUserQuery_PROD
+type BadgesChallengedQuery = BadgesChallengedQuery_DEV | BadgesChallengedQuery_STAGING | BadgesChallengedQuery_PROD
+type BadgesInReviewOrChallengedQuery =
+  | BadgesInReviewOrChallengedQuery_DEV
+  | BadgesInReviewOrChallengedQuery_STAGING
+  | BadgesInReviewOrChallengedQuery_PROD
+type BadgesInReviewQuery = BadgesInReviewQuery_DEV | BadgesInReviewQuery_STAGING | BadgesInReviewQuery_PROD
+type BadgeStatus = BadgeStatus_DEV | BadgeStatus_STAGING | BadgeStatus_PROD
+type BadgesUserCanReviewQuery =
+  | BadgesUserCanReviewQuery_DEV
+  | BadgesUserCanReviewQuery_STAGING
+  | BadgesUserCanReviewQuery_PROD
+type BadgesOfUserByStatusesQuery =
+  | BadgesOfUserByStatusesQuery_DEV
+  | BadgesOfUserByStatusesQuery_STAGING
+  | BadgesOfUserByStatusesQuery_PROD
+type BadgesNotOfUserByStatusesQuery =
+  | BadgesNotOfUserByStatusesQuery_DEV
+  | BadgesNotOfUserByStatusesQuery_STAGING
+  | BadgesNotOfUserByStatusesQuery_PROD
+type Badge_Filter = Badge_Filter_DEV | Badge_Filter_STAGING | Badge_Filter_PROD
+type BadgesQuery = BadgesQuery_DEV | BadgesQuery_STAGING | BadgesQuery_PROD
+type BadgeMetadataByIdQuery = BadgeMetadataByIdQuery_DEV | BadgeMetadataByIdQuery_STAGING | BadgeMetadataByIdQuery_PROD
+type BadgesMetadataUserHasChallengedQuery =
+  | BadgesMetadataUserHasChallengedQuery_DEV
+  | BadgesMetadataUserHasChallengedQuery_STAGING
+  | BadgesMetadataUserHasChallengedQuery_PROD
 
 interface BadgesServiceMethods {
   get(searchParams?: { first: number; skip: number; filter?: Badge_Filter }): Promise<BadgesQuery>

--- a/src/services/users/users.ts
+++ b/src/services/users/users.ts
@@ -1,17 +1,76 @@
 import {
-  Badge_Filter,
-  UserBadgesFilteredQuery,
-  UserQuery,
-  CreatorUsersIdQuery,
-  UsersIdQuery,
-  UserBadgesByModelIdQuery,
-  UserCreatedBadgeModelsQuery,
-  UserBadgesChallengedQuery,
-  UserBadgesInReviewQuery,
-  UserBadgesInReviewOrChallengedQuery,
-  UserBadgesExpiringBetweenQuery,
+  Badge_Filter as Badge_Filter_DEV,
+  UserBadgesFilteredQuery as UserBadgesFilteredQuery_DEV,
+  UserQuery as UserQuery_DEV,
+  CreatorUsersIdQuery as CreatorUsersIdQuery_DEV,
+  UsersIdQuery as UsersIdQuery_DEV,
+  UserBadgesByModelIdQuery as UserBadgesByModelIdQuery_DEV,
+  UserCreatedBadgeModelsQuery as UserCreatedBadgeModelsQuery_DEV,
+  UserBadgesChallengedQuery as UserBadgesChallengedQuery_DEV,
+  UserBadgesInReviewQuery as UserBadgesInReviewQuery_DEV,
+  UserBadgesInReviewOrChallengedQuery as UserBadgesInReviewOrChallengedQuery_DEV,
+  UserBadgesExpiringBetweenQuery as UserBadgesExpiringBetweenQuery_DEV,
+} from '@subgraph/dev/generated/subgraph'
+import {
+  Badge_Filter as Badge_Filter_STAGING,
+  UserBadgesFilteredQuery as UserBadgesFilteredQuery_STAGING,
+  UserQuery as UserQuery_STAGING,
+  CreatorUsersIdQuery as CreatorUsersIdQuery_STAGING,
+  UsersIdQuery as UsersIdQuery_STAGING,
+  UserBadgesByModelIdQuery as UserBadgesByModelIdQuery_STAGING,
+  UserCreatedBadgeModelsQuery as UserCreatedBadgeModelsQuery_STAGING,
+  UserBadgesChallengedQuery as UserBadgesChallengedQuery_STAGING,
+  UserBadgesInReviewQuery as UserBadgesInReviewQuery_STAGING,
+  UserBadgesInReviewOrChallengedQuery as UserBadgesInReviewOrChallengedQuery_STAGING,
+  UserBadgesExpiringBetweenQuery as UserBadgesExpiringBetweenQuery_STAGING,
+} from '@subgraph/staging/generated/subgraph'
+import {
+  Badge_Filter as Badge_Filter_PROD,
+  UserBadgesFilteredQuery as UserBadgesFilteredQuery_PROD,
+  UserQuery as UserQuery_PROD,
+  CreatorUsersIdQuery as CreatorUsersIdQuery_PROD,
+  UsersIdQuery as UsersIdQuery_PROD,
+  UserBadgesByModelIdQuery as UserBadgesByModelIdQuery_PROD,
+  UserCreatedBadgeModelsQuery as UserCreatedBadgeModelsQuery_PROD,
+  UserBadgesChallengedQuery as UserBadgesChallengedQuery_PROD,
+  UserBadgesInReviewQuery as UserBadgesInReviewQuery_PROD,
+  UserBadgesInReviewOrChallengedQuery as UserBadgesInReviewOrChallengedQuery_PROD,
+  UserBadgesExpiringBetweenQuery as UserBadgesExpiringBetweenQuery_PROD,
 } from '@subgraph/prod/generated/subgraph'
 import { TheBadgeSDKConfig } from '@businessLogic/sdk/config'
+
+type Badge_Filter = Badge_Filter_DEV | Badge_Filter_STAGING | Badge_Filter_PROD
+type UserBadgesFilteredQuery =
+  | UserBadgesFilteredQuery_DEV
+  | UserBadgesFilteredQuery_STAGING
+  | UserBadgesFilteredQuery_PROD
+type UserQuery = UserQuery_DEV | UserQuery_STAGING | UserQuery_PROD
+type CreatorUsersIdQuery = CreatorUsersIdQuery_DEV | CreatorUsersIdQuery_STAGING | CreatorUsersIdQuery_PROD
+type UsersIdQuery = UsersIdQuery_DEV | UsersIdQuery_STAGING | UsersIdQuery_PROD
+type UserBadgesByModelIdQuery =
+  | UserBadgesByModelIdQuery_DEV
+  | UserBadgesByModelIdQuery_STAGING
+  | UserBadgesByModelIdQuery_PROD
+type UserCreatedBadgeModelsQuery =
+  | UserCreatedBadgeModelsQuery_DEV
+  | UserCreatedBadgeModelsQuery_STAGING
+  | UserCreatedBadgeModelsQuery_PROD
+type UserBadgesChallengedQuery =
+  | UserBadgesChallengedQuery_DEV
+  | UserBadgesChallengedQuery_STAGING
+  | UserBadgesChallengedQuery_PROD
+type UserBadgesInReviewQuery =
+  | UserBadgesInReviewQuery_DEV
+  | UserBadgesInReviewQuery_STAGING
+  | UserBadgesInReviewQuery_PROD
+type UserBadgesInReviewOrChallengedQuery =
+  | UserBadgesInReviewOrChallengedQuery_DEV
+  | UserBadgesInReviewOrChallengedQuery_STAGING
+  | UserBadgesInReviewOrChallengedQuery_PROD
+type UserBadgesExpiringBetweenQuery =
+  | UserBadgesExpiringBetweenQuery_DEV
+  | UserBadgesExpiringBetweenQuery_STAGING
+  | UserBadgesExpiringBetweenQuery_PROD
 
 interface UsersServiceMethods {
   getIds(searchParams?: { first: number; skip: number }): Promise<UsersIdQuery>


### PR DESCRIPTION
This resolves the problem receiving the wrong object type when fragments differ between subgraphs for different envs.
